### PR TITLE
Morph: migrate to permission service

### DIFF
--- a/src/clients/permission-service.client.ts
+++ b/src/clients/permission-service.client.ts
@@ -34,14 +34,15 @@ export class PermissionServiceClient {
     console.log(`[PermissionServiceClient] Initialized with baseUrl: ${this.baseUrl}`);
   }
 
-  async hasPermission(subjectId: string, domain: Domain, action: Action): Promise<boolean> {
-    console.log(`[PermissionServiceClient] Checking permission for subjectId=${subjectId}, domain=${domain}, action=${action}`);
+  async hasPermission(subjectId: string, tenantId: string, domain: Domain, action: Action): Promise<boolean> {
+    console.log(`[PermissionServiceClient] Checking permission for subjectId=${subjectId}, tenantId=${tenantId}, domain=${domain}, action=${action}`);
     try {
       const response = await axios.get<PermissionResponse>(
-        `${this.baseUrl}/permissions/check`,
+        `${this.baseUrl}/permissions/v2/check`,
         {
           params: {
             subjectId,
+            tenantId,
             domain,
             action
           }
@@ -51,7 +52,6 @@ export class PermissionServiceClient {
       return response.data.allowed;
     } catch (error) {
       if (axios.isAxiosError(error)) {
-        // Handle specific error cases if needed
         console.error(`[PermissionServiceClient] Permission check failed: ${error.message}`);
       } else {
         console.error(`[PermissionServiceClient] Unexpected error during permission check: ${error}`);

--- a/src/controllers/notification.controller.ts
+++ b/src/controllers/notification.controller.ts
@@ -11,10 +11,17 @@ export class NotificationController {
   async confirmNotification(req: Request, res: Response): Promise<void> {
     try {
       const userId = this.identityProvider.getUserId(req);
-      console.log(`[NotificationController] confirmNotification called by userId: ${userId}`);
+      const tenantId = this.identityProvider.getTenantId(req);
+      console.log(`[NotificationController] confirmNotification called by userId: ${userId}, tenantId: ${tenantId}`);
+      
       if (!userId) {
         console.warn('[NotificationController] User ID not found in request');
         res.status(401).json({ error: 'User ID not found' });
+        return;
+      }
+      if (!tenantId) {
+        console.warn('[NotificationController] Tenant ID not found in request');
+        res.status(401).json({ error: 'Tenant ID not found' });
         return;
       }
 
@@ -26,8 +33,8 @@ export class NotificationController {
         return;
       }
 
-      await this.notificationService.confirmNotification(userId, notificationId);
-      console.log(`[NotificationController] Notification ${notificationId} confirmed for user ${userId}`);
+      await this.notificationService.confirmNotification(userId, tenantId, notificationId);
+      console.log(`[NotificationController] Notification ${notificationId} confirmed for user ${userId} in tenant ${tenantId}`);
       res.status(200).json({ message: 'Notification confirmed successfully' });
     } catch (error) {
       if (error instanceof Error && error.message === 'Insufficient permissions') {

--- a/src/middleware/identity.provider.ts
+++ b/src/middleware/identity.provider.ts
@@ -7,4 +7,11 @@ export class IdentityProvider {
     console.log(`[IdentityProvider] Extracted userId: ${userId}`);
     return userId || null;
   }
+
+  getTenantId(req: Request): string | null {
+    console.log(`[IdentityProvider] Received headers: ${JSON.stringify(req.headers)}`);
+    const tenantId = req.header('identity-tenant-id');
+    console.log(`[IdentityProvider] Extracted tenantId: ${tenantId}`);
+    return tenantId || null;
+  }
 }

--- a/src/services/notification.service.ts
+++ b/src/services/notification.service.ts
@@ -5,20 +5,21 @@ export class NotificationService {
 
   constructor(private permissionServiceClient: PermissionServiceClient) {}
 
-  async confirmNotification(userId: string, notificationId: string): Promise<void> {
-    console.log(`Checking permission for userId=${userId} on notificationId=${notificationId}`);
+  async confirmNotification(userId: string, tenantId: string, notificationId: string): Promise<void> {
+    console.log(`Checking permission for userId=${userId}, tenantId=${tenantId} on notificationId=${notificationId}`);
     const hasPermission = await this.permissionServiceClient.hasPermission(
       userId,
+      tenantId,
       Domain.NOTIFICATION,
       Action.UPDATE
     );
 
     if (!hasPermission) {
-      console.log(`Permission denied for userId=${userId} on notificationId=${notificationId}`);
+      console.log(`Permission denied for userId=${userId}, tenantId=${tenantId} on notificationId=${notificationId}`);
       throw new Error('Insufficient permissions');
     }
 
-    console.log(`Confirming notificationId=${notificationId} for userId=${userId}`);
+    console.log(`Confirming notificationId=${notificationId} for userId=${userId} in tenant ${tenantId}`);
     this.confirmedNotifications.add(notificationId);
   }
 


### PR DESCRIPTION
This PR contains the following modifications:

- AI (gemini/gemini-2.5-flash-lite):
```
The company is moving to multi-tenant setup. This means we need to re-work how we evaluate permissions. Infra team has already implemented authentication and they add new identity-tenant-id header in the api-gateway.

The owners of permission-service have already implemented a new endpoint /permissions/v2/check that can accept tenantId along with existing subjectId.

So now all the other components need to be updated to the new version of permission-service. But all the feature teams are busy with building a new shiny AI integration and can not prioritize this upgrade.

Do not keep the old logic in permission service client.

```
 (Slicing enabled: No)

Generated by [Morph](https://codemorph.dev)