### PR TITLE
Morph: Permission service migration

### DIFF
--- a/src/clients/permission-service.client.ts
+++ b/src/clients/permission-service.client.ts
@@ -34,16 +34,17 @@ export class PermissionServiceClient {
     console.log(`[PermissionServiceClient] Initialized with baseUrl: ${this.baseUrl}`);
   }
 
-  async hasPermission(subjectId: string, domain: Domain, action: Action): Promise<boolean> {
-    console.log(`[PermissionServiceClient] Checking permission for subjectId=${subjectId}, domain=${domain}, action=${action}`);
+  async hasPermission(subjectId: string, domain: Domain, action: Action, tenantId?: string): Promise<boolean> {
+    console.log(`[PermissionServiceClient] Checking permission for subjectId=${subjectId}, domain=${domain}, action=${action}, tenantId=${tenantId}`);
     try {
       const response = await axios.get<PermissionResponse>(
-        `${this.baseUrl}/permissions/check`,
+        `${this.baseUrl}/v2/permissions/check`,
         {
           params: {
             subjectId,
             domain,
-            action
+            action,
+            tenantId
           }
         }
       );

--- a/src/controllers/notification.controller.ts
+++ b/src/controllers/notification.controller.ts
@@ -26,7 +26,8 @@ export class NotificationController {
         return;
       }
 
-      await this.notificationService.confirmNotification(userId, notificationId);
+      const tenantId = this.identityProvider.getTenantId(req);
+      await this.notificationService.confirmNotification(userId, notificationId, tenantId);
       console.log(`[NotificationController] Notification ${notificationId} confirmed for user ${userId}`);
       res.status(200).json({ message: 'Notification confirmed successfully' });
     } catch (error) {

--- a/src/middleware/identity.provider.ts
+++ b/src/middleware/identity.provider.ts
@@ -7,4 +7,10 @@ export class IdentityProvider {
     console.log(`[IdentityProvider] Extracted userId: ${userId}`);
     return userId || null;
   }
+
+  getTenantId(req: Request): string | null {
+    const tenantId = req.header('identity-tenant-id');
+    console.log(`[IdentityProvider] Extracted tenantId: ${tenantId}`);
+    return tenantId || null;
+  }
 }

--- a/src/services/notification.service.ts
+++ b/src/services/notification.service.ts
@@ -5,12 +5,13 @@ export class NotificationService {
 
   constructor(private permissionServiceClient: PermissionServiceClient) {}
 
-  async confirmNotification(userId: string, notificationId: string): Promise<void> {
-    console.log(`Checking permission for userId=${userId} on notificationId=${notificationId}`);
+  async confirmNotification(userId: string, notificationId: string, tenantId?: string): Promise<void> {
+    console.log(`Checking permission for userId=${userId} on notificationId=${notificationId} for tenant=${tenantId}`);
     const hasPermission = await this.permissionServiceClient.hasPermission(
       userId,
       Domain.NOTIFICATION,
-      Action.UPDATE
+      Action.UPDATE,
+      tenantId
     );
 
     if (!hasPermission) {


### PR DESCRIPTION
This PR contains the following modifications:

- AI (deepseek/deepseek-chat):
```
The company is moving to multi-tenant setup. This means we need to re-work how we evaluate permissions. Infra team has already implemented authentication and they add new identity-tenant-id header in the api-gateway.

The owners of permission-service have already implemented a new endpoint /v2/check that can accept tenantId along with existing subjectId.

So now all the other components need to be updated to the new version of permission-service. But all the feature teams are busy with building a new shiny AI integration and can not prioritize this upgrade.

The only hope is you.
```
 (Slicing enabled: No)

Generated by [Morph](https://codemorph.dev)